### PR TITLE
ci: GitHub Actions 배포 파이프라인 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: "🐛 Bug"
+description: "예상과 다른 동작 보고"
+title: "[BUG] "
+labels: ["bug", "sp001"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: 요약
+      placeholder: 로그인 버튼 클릭 시 앱 크래시
+  - type: textarea
+    id: steps
+    attributes:
+      label: 재현 절차
+      placeholder: |
+        1. 앱 실행
+        2. 로그인 버튼 탭
+        3. ...
+  - type: textarea
+    id: result
+    attributes:
+      label: 예상 결과 vs 실제 결과
+      placeholder: |
+        **예상:**  
+        **실제:**
+  - type: dropdown
+    id: platform
+    attributes:
+      label: 플랫폼
+      multiple: true
+      options: [iOS, Android, Both]
+  - type: input
+    id: env
+    attributes:
+      label: 기기 / OS / 앱 버전
+      placeholder: Galaxy S24 / Android 15 / v0.4.1
+  - type: textarea
+    id: media
+    attributes:
+      label: 스크린샷·로그
+      description: 이미지·GIF·expo.dev logs 첨부
+  - type: textarea
+    id: notes
+    attributes:
+      label: 추가 정보

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,18 @@
+name: "🔧 Chore"
+description: "빌드, 의존성, 문서 등 잡무"
+title: "[CHORE] "
+labels: ["chore", "sp001"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: 작업 요약
+  - type: textarea
+    id: details
+    attributes:
+      label: 세부 내용
+  - type: textarea
+    id: impact
+    attributes:
+      label: 영향 범위
+      placeholder: 빌드 시간, 패키지 크기 등

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,55 @@
+name: "📌 Epic"
+description: "스프린트·대규모 기능 등 상위 목표 정의"
+title: "[EPIC] "
+labels: ["epic"]
+body:
+  - type: input
+    id: goal
+    attributes:
+      label: 목표(Goal)
+      placeholder: SP001 MVP 릴리스
+  - type: input
+    id: timeline
+    attributes:
+      label: 기간(Timeline)
+      placeholder: 2025-07-07 - 2025-07-23
+  - type: textarea
+    id: scope
+    attributes:
+      label: 범위(Scope)
+      description: 포함·제외 항목을 명확히
+      placeholder: |
+        포함: 온보딩, 질문 작성, 알림  
+        제외: 구독 결제
+  - type: textarea
+    id: user_stories
+    attributes:
+      label: 사용자 스토리(User Stories)
+      placeholder: |
+        - 사용자는 온보딩 화면을 통해 앱 기능을 이해할 수 있다.
+        - 사용자는 질문을 작성하고 업로드할 수 있다.
+  - type: textarea
+    id: success_criteria
+    attributes:
+      label: 성공 기준(Success Criteria)
+      placeholder: |
+        - 온보딩 완료율 70% 이상
+        - 질문 작성 후 1주일 내 3회 이상 앱 방문
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: 산출물(Deliverables)
+      placeholder: TestFlight 빌드, 관리자 웹 MVP
+  - type: textarea
+    id: checklist
+    attributes:
+      label: 하위 이슈 체크리스트
+      description: "- [ ] #issue_number 형식으로 작성 시 자동 링크"
+      placeholder: |
+        - [ ] #12 온보딩 Carousel
+        - [ ] #13 질문 업로드
+  - type: textarea
+    id: resources
+    attributes:
+      label: 참고자료(Resources)
+      placeholder: Notion 문서, Figma, 외부 레퍼런스 링크

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: "✨ Feature"
+description: "기능 제안·개선 요청"
+title: "[FEAT] "
+labels: ["feature", "sp001"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 한줄 설명
+      placeholder: |
+        #### Story 1.x
+        다크모드 토글 추가
+  - type: textarea
+    id: context
+    attributes:
+      label: 문제·기회
+      description: 왜 필요한가?
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 제안 내용
+      placeholder: |
+        * UX 흐름 / Figma 링크  
+        * API 스펙  
+        * 완료 기준(AC)
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: 완료 기준(AC)
+      description: |
+        완료 기준을 명확히 작성해 주세요.
+      placeholder: |
+        * 사용자는 다크모드를 토글할 수 있다.  
+        * 다크모드 설정은 로컬 스토리지에 저장된다.
+        * 다크모드 설정은 페이지를 새로고침해도 유지된다.
+  - type: textarea
+    id: refs
+    attributes:
+      label: 관련 참고자료
+      placeholder: Notion, 블로그, RFC 등 링크
+  - type: textarea
+    id: deps
+    attributes:
+      label: 관련 이슈·블로커

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+name: Deploy DisasterKok to AWS EC2
+
+on:
+  push:
+    branches: [main, develop]
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: disasterkok-backend
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image to ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build --platform linux/amd64 \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} \
+                     $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          echo "ECR_REGISTRY=$ECR_REGISTRY" >> $GITHUB_ENV
+
+      - name: Deploy to EC2 via SSH
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ec2-user
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            aws ecr get-login-password --region ap-northeast-2 | \
+              docker login --username AWS \
+              --password-stdin ${{ env.ECR_REGISTRY }}
+
+            cd /home/ec2-user/disasterkok
+            export ECR_REGISTRY=${{ env.ECR_REGISTRY }}
+            docker-compose -f docker-compose.prod.yml pull
+            docker-compose -f docker-compose.prod.yml up -d --remove-orphans
+
+            docker-compose -f docker-compose.prod.yml exec -T gunicorn \
+              python manage.py migrate --no-input
+
+            docker system prune -f


### PR DESCRIPTION
## 📊 요약

main/develop 브랜치 push 시 ECR 이미지 빌드 → EC2 자동 배포 파이프라인 구성.
로컬 빌드 의존성 제거 및 amd64 플랫폼 명시로 Mac arm64 환경과의 아키텍처 불일치 해결.

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [ ] ✨ 기능
- [ ] 🐛 버그
- [ ] ♻️ 리팩터
- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

- `.github/workflows/deploy.yml` 추가
  - `ubuntu-latest` 러너에서 `linux/amd64` 플랫폼으로 이미지 빌드
  - ECR push → `appleboy/ssh-action`으로 EC2 배포 자동화
  - 배포 후 `migrate --no-input` 자동 실행
  - `docker system prune -f`로 오래된 이미지 정리

### 📣 리뷰 노트

GitHub Secrets 4개 사전 등록 필요:
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `EC2_HOST`
- `EC2_SSH_KEY`

## 🔗 관련 이슈

`Closes #` / `Fixes #`